### PR TITLE
Change "temporary" keyword to "temp"

### DIFF
--- a/apache-mode.el
+++ b/apache-mode.el
@@ -1033,7 +1033,7 @@
         "SuppressSize"
         "SymLinksIfOwnerMatch"
         "sysvsem"
-        "temporary"
+        "temp"
         "tpfcore"
         "unformatted"
         "unset"


### PR DESCRIPTION
```
  temp
  Returns a temporary redirect status (302). This is the default.
```
  https://httpd.apache.org/docs/2.4/mod/mod_alias.html

Fix for Debian bug #799355